### PR TITLE
Fix scheduler cron bug

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -210,15 +210,22 @@ if [ "$deploy_process_type" = "scheduledtasks" ]; then
 	echo "----> Deploying scheduled tasks as EventBridge rules"
 	deploy_scheduled_tasks_path=$(grep scheduledtasks Procfile | cut -d':' -f2 | xargs)
 	if [ -f "$deploy_scheduled_tasks_path" ]; then
-        deploy_alb_subnets=$(jq --raw-input --raw-output 'split(",")' <<<"$ECS_SERVICE_SUBNETS")
-        deploy_alb_security_groups=$(jq --raw-input --raw-output 'split(",")' <<<"$ECS_SERVICE_SECURITY_GROUPS")
+		deploy_alb_subnets=$(jq --raw-input --raw-output 'split(",")' <<<"$ECS_SERVICE_SUBNETS")
+		deploy_alb_security_groups=$(jq --raw-input --raw-output 'split(",")' <<<"$ECS_SERVICE_SECURITY_GROUPS")
+
 		while IFS= read -r line; do
-			deploy_scheduled_task_name=$(echo $line | cut -d' ' -f1)
+			if [ -z $line ]; then
+				break
+			fi
+    	# Use $line value literally
+			line=$(echo "$line")
+
+			deploy_scheduled_task_name=$(echo "$line" | cut -d' ' -f1)
 			aws events put-rule \
 			--name $deploy_scheduled_task_name \
-			--schedule "$(echo $line | cut -d' ' -f2- | cut -d')' -f1))"
+			--schedule "$(echo "$line" | cut -d' ' -f2- | cut -d')' -f1))"
 
-			deploy_command_override=$(echo $line | cut -d')' -f2 | xargs)
+			deploy_command_override=$(echo "$line" | cut -d')' -f2 | xargs)
 			echo "----> Defining scheduled task $deploy_scheduled_task_name with command $deploy_command_override"
 			aws events put-targets \
 			--rule $deploy_scheduled_task_name \

--- a/deploy.sh
+++ b/deploy.sh
@@ -214,11 +214,9 @@ if [ "$deploy_process_type" = "scheduledtasks" ]; then
 		deploy_alb_security_groups=$(jq --raw-input --raw-output 'split(",")' <<<"$ECS_SERVICE_SECURITY_GROUPS")
 
 		while IFS= read -r line; do
-			if [ -z $line ]; then
+			if [ -z "$line" ]; then
 				break
 			fi
-    	# Use $line value literally
-			line=$(echo "$line")
 
 			deploy_scheduled_task_name=$(echo "$line" | cut -d' ' -f1)
 			aws events put-rule \


### PR DESCRIPTION
Fix a error when reading the line value extracted from a file, if the line has a * it is converted to a list of files, breaking the comand.
Ex; schedule-sample cron(0 15 * * ?  *) ...

Check if the line is empty and stop the loop.