### PR TITLE
Run release tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,20 @@ phases:
 
 ### **Extra Features**
 
-- Able to enable creation of scheduled tasks
+- Creation of scheduled tasks
+- Execution of code before release (database migrations, assets upload, etc)
+
+### **Procfile**
+
+Below you can see a sample `Procfile` that demonstrates some of Maestro's capabilities:
+
+```
+web: bundle exec unicorn -p $PORT -c config/unicorn.rb # binds unicorn via $PORT to an ALB for incoming traffic
+worker: bundle exec sidekiq -C config/sidekiq.yml      # runs sidekiq for processing background jobs
+clock: bundle exec rails runner bin/clock              # loads a cron based service that will trigger commands
+scheduledtasks: tasks.run                              # creates tasks for one-off executions scheduled at tasks.run
+release: bundle exec db:migrate                        # runs database migration right before the release is deployed
+```
 
 ### **Environment Variables**
 

--- a/build.sh
+++ b/build.sh
@@ -26,14 +26,26 @@ if [ -z "$build_image_name" ]; then
 	exit 1
 fi
 
-if [ $(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $build_image_name > /dev/null ; echo $?) -eq 0 ]; then
+if [ $(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $build_image_name 2> /dev/null ; echo $?) -eq 0 ]; then
 	echo "----> Skipping build as image already exists"
 else
-	pack build $build_image_name \
+	build_builder_name=`grep builder project.toml | cut -d= -f2 | tr -d '" '`
+	build_builder_tag=`echo $build_builder_name | tr /: -`
+	docker pull --quiet ${build_image_name%:*}:$build_builder_tag 2> /dev/null || true
+	docker tag ${build_image_name%:*}:$build_builder_tag $build_builder_name 2> /dev/null || true
+    build_assume_role=$(curl -s http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
+	echo "AWS_ACCESS_KEY_ID=$(jq -r '.AccessKeyId' <<<$build_assume_role)" >> .env
+	echo "AWS_SECRET_ACCESS_KEY=$(jq -r '.SecretAccessKey' <<<$build_assume_role)" >> .env
+	echo "AWS_SESSION_TOKEN=$(jq -r '.Token' <<<$build_assume_role)" >> .env
+	pack build ${build_image_name%:*}:latest \
+	--tag $build_image_name \
 	--env-file .env \
 	--publish \
 	--trust-builder \
-    $( [   -z $MAESTRO_NO_CACHE ] && echo "--cache-image ${build_image_name%:*}:cache") \
-    $( [ ! -z $MAESTRO_CLEAR_CACHE ] && echo "--clear-cache --env USE_YARN_CACHE=false --env NODE_MODULES_CACHE=false") \
-    $( [ ! -z $MAESTRO_DEBUG ] && echo "--env NPM_CONFIG_LOGLEVEL=debug --env NODE_VERBOSE=true --verbose")
+	--pull-policy if-not-present \
+    $( [[ -z $MAESTRO_NO_CACHE || $MAESTRO_NO_CACHE = "false" ]] && echo "--cache-image ${build_image_name%:*}:cache") \
+    $( [ $MAESTRO_CLEAR_CACHE = "true" ] && echo "--clear-cache --env USE_YARN_CACHE=false --env NODE_MODULES_CACHE=false") \
+    $( [ $MAESTRO_DEBUG = "true" ] && echo "--env NPM_CONFIG_LOGLEVEL=debug --env NODE_VERBOSE=true --verbose")
+    docker tag $build_builder_name ${build_image_name%:*}:$build_builder_tag
+	docker push --quiet ${build_image_name%:*}:$build_builder_tag
 fi

--- a/render.sh
+++ b/render.sh
@@ -102,7 +102,7 @@ if [ "${render_is_task_definition_array}" == "false" ]; then
 	exit 1
 fi
 
-echo "----> Looking for $render_container_name"
+echo "----> Looking for container named  $render_container_name"
 render_is_container_name_present=$(jq ".containerDefinitions[] | select(.name==\"$render_container_name\")" $render_task_definition)
 if [ -z "$render_is_container_name_present" ]; then
 	echo "Error: '$render_container_name' was not found on task definition"


### PR DESCRIPTION
Please notice that there is a second commented option for release that will trigger a one-off task and run it on ECS, wait for its return and continue in case there is a clean exit code. @fagianijunior and @HaseoBoss we need to provide a ENV to define which one to use and maybe default it to docker in docker as it is now. Both approaches work well as tested so far.

Please do not merge before finishing this implementation.