### PR TITLE
Adds a suffix to the scheduled_task_name, fixing eventbridge conflict…

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -250,13 +250,7 @@ if [ "$deploy_process_type" = "scheduledtasks" ]; then
 				break
 			fi
 
-			deploy_scheduled_task_name=$(echo "$line" | cut -d' ' -f1)-$deploy_cluster_id_hash
-
-			if [ ${#deploy_scheduled_task_name} -gt 64 ]; then
-  			echo "ERROR: scheduled task name ($deploy_scheduled_task_name) is too long, it \
-  						must be less than or equal to 64 characters."
-  			exit 1
-			fi
+			deploy_scheduled_task_name=$(echo "$deploy_cluster_id_hash-$(echo "$line" | cut -d' ' -f1)" | cut -c1-64)
 
 			aws events put-rule \
 			--name $deploy_scheduled_task_name \


### PR DESCRIPTION
…s if there are two environments in the same account for the same project using scheduled tasks.
Fails if the scheduled task name exceeds 64 characters.