### PR TITLE
define resource tag variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN set -ex \
     && useradd -g dockremap dockremap \
     && echo 'dockremap:165536:65536' >> /etc/subuid \
     && echo 'dockremap:165536:65536' >> /etc/subgid \
-    && wget -nv "https://raw.githubusercontent.com/rollbar/docker/refs/heads/master/hack/dind" -O /usr/local/bin/dind \
+    && wget -nv "https://raw.githubusercontent.com/moby/moby/master/hack/dind" -O /usr/local/bin/dind \
     && curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
     && docker-compose version

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN set -ex \
     && useradd -g dockremap dockremap \
     && echo 'dockremap:165536:65536' >> /etc/subuid \
     && echo 'dockremap:165536:65536' >> /etc/subgid \
-    && wget -nv "https://raw.githubusercontent.com/moby/moby/master/hack/dind" -O /usr/local/bin/dind \
+    && wget -nv "https://raw.githubusercontent.com/rollbar/docker/refs/heads/master/hack/dind" -O /usr/local/bin/dind \
     && curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/dind /usr/local/bin/docker-compose \
     && docker-compose version

--- a/deploy.sh
+++ b/deploy.sh
@@ -131,7 +131,7 @@ if [[ $deploy_process_type != "scheduledtasks" && ( -z "$ECS_SERVICE_TASK_PROCES
 		if [ ! -z "$deploy_json_workload_resource_tags" ]; then
 			aws ecs tag-resource \
 				--resource-arn "$deploy_service_arn" \
-				--tags "$deploy_json_workload_resource_tags"
+				--tags $deploy_json_workload_resource_tags
 		fi
 	fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -71,6 +71,9 @@ if [ -z "$deploy_service_name" ]; then
 fi
 
 release_arn=$(cat .releasearn)
+deploy_json_workload_resource_tags=$(jq --raw-input --raw-output '[ split(",") | .[] | "key=" + split("=")[0] + ",value=" + split("=")[1] ] | join(" ")' <<<"$WORKLOAD_RESOURCE_TAGS")
+deploy_json_workload_resource_tags_captalized=$(jq --raw-input --raw-output '[ split(",") | .[] | "Key=" + split("=")[0] + ",Value=" + split("=")[1] ] | join(" ")' <<<"$WORKLOAD_RESOURCE_TAGS")
+
 if [[ $deploy_process_type != "scheduledtasks" && ( -z "$ECS_SERVICE_TASK_PROCESSES" || $ECS_SERVICE_TASK_PROCESSES =~ $deploy_process_type ) ]]; then
 	if [[ $deploy_process_type = "web" ]]; then
 		provision_target_group_arn=$(cat .tgarn)


### PR DESCRIPTION
adicionei o trecho abaixo em `deploy.sh` para definir a variavel e garantir que ela nao vai ficar vazia:

```
deploy_json_workload_resource_tags=$(jq --raw-input --raw-output '[ split(",") | .[] | "key=" + split("=")[0] + ",value=" + split("=")[1] ] | join(" ")' <<<"$WORKLOAD_RESOURCE_TAGS")
deploy_json_workload_resource_tags_captalized=$(jq --raw-input --raw-output '[ split(",") | .[] | "Key=" + split("=")[0] + ",Value=" + split("=")[1] ] | join(" ")' <<<"$WORKLOAD_RESOURCE_TAGS")
```